### PR TITLE
Add collision system to prevent camera passing through cube

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -1,4 +1,7 @@
 use cgmath::{EuclideanSpace, InnerSpace, Matrix4, Point3, Rad, Vector3};
+use crate::collision::Aabb;
+
+pub const CAMERA_HALF_SIZE: f32 = 0.1;
 
 pub enum CameraMovement {
     Forward,
@@ -51,6 +54,30 @@ impl Camera {
         }
     }
 
+    pub fn process_keyboard_collision(&mut self, direction: CameraMovement, dt: f32, colliders: &[Aabb]) {
+        let velocity = self.speed * dt;
+        let front = self.front();
+        let right = front.cross(Vector3::unit_z()).normalize();
+        let mut new_pos = self.position;
+        match direction {
+            CameraMovement::Forward => new_pos += front * velocity,
+            CameraMovement::Backward => new_pos -= front * velocity,
+            CameraMovement::Left => new_pos -= right * velocity,
+            CameraMovement::Right => new_pos += right * velocity,
+            CameraMovement::Up => new_pos += Vector3::unit_z() * velocity,
+            CameraMovement::Down => new_pos -= Vector3::unit_z() * velocity,
+        }
+
+        let proposed = Aabb::new(
+            new_pos - Vector3::new(CAMERA_HALF_SIZE, CAMERA_HALF_SIZE, CAMERA_HALF_SIZE),
+            new_pos + Vector3::new(CAMERA_HALF_SIZE, CAMERA_HALF_SIZE, CAMERA_HALF_SIZE),
+        );
+
+        if !colliders.iter().any(|c| proposed.intersects(c)) {
+            self.position = new_pos;
+        }
+    }
+
     pub fn process_mouse(&mut self, dx: f32, dy: f32) {
         self.yaw += dx * self.sensitivity;
         self.pitch = (self.pitch + dy * self.sensitivity).clamp(-89.0, 89.0);
@@ -65,5 +92,12 @@ impl Camera {
             pitch.0.sin(),
         )
         .normalize()
+    }
+
+    pub fn aabb(&self) -> Aabb {
+        Aabb::new(
+            self.position - Vector3::new(CAMERA_HALF_SIZE, CAMERA_HALF_SIZE, CAMERA_HALF_SIZE),
+            self.position + Vector3::new(CAMERA_HALF_SIZE, CAMERA_HALF_SIZE, CAMERA_HALF_SIZE),
+        )
     }
 }

--- a/src/collision.rs
+++ b/src/collision.rs
@@ -1,0 +1,20 @@
+use cgmath::Vector3;
+
+#[derive(Clone, Copy, Debug)]
+pub struct Aabb {
+    pub min: Vector3<f32>,
+    pub max: Vector3<f32>,
+}
+
+impl Aabb {
+    pub fn new(min: Vector3<f32>, max: Vector3<f32>) -> Self {
+        Self { min, max }
+    }
+
+    pub fn intersects(&self, other: &Aabb) -> bool {
+        self.min.x <= other.max.x && self.max.x >= other.min.x &&
+        self.min.y <= other.max.y && self.max.y >= other.min.y &&
+        self.min.z <= other.max.z && self.max.z >= other.min.z
+    }
+}
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,10 @@
 mod vulkan_app;
 mod camera;
+mod collision;
 
 use vulkan_app::{VulkanApp, HEIGHT, WIDTH};
 use camera::{Camera, CameraMovement};
+use collision::Aabb;
 use winit::event::{Event, WindowEvent, DeviceEvent, ElementState, KeyboardInput, VirtualKeyCode};
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit::window::WindowBuilder;
@@ -17,6 +19,10 @@ fn main() {
 
     let mut app = VulkanApp::new(&window);
     let mut camera = Camera::new(cgmath::Vector3::new(2.0, 2.0, 2.0), -135.0, -35.0);
+    let cube_collider = Aabb::new(
+        cgmath::Vector3::new(-0.5, -0.5, -0.5),
+        cgmath::Vector3::new(0.5, 0.5, 0.5),
+    );
 
     let mut input_state = InputState::default();
     let mut last_frame = std::time::Instant::now();
@@ -91,12 +97,13 @@ fn main() {
                 let dt = now.duration_since(last_frame).as_secs_f32();
                 last_frame = now;
 
-                if input_state.forward { camera.process_keyboard(CameraMovement::Forward, dt); }
-                if input_state.backward { camera.process_keyboard(CameraMovement::Backward, dt); }
-                if input_state.left { camera.process_keyboard(CameraMovement::Left, dt); }
-                if input_state.right { camera.process_keyboard(CameraMovement::Right, dt); }
-                if input_state.up { camera.process_keyboard(CameraMovement::Up, dt); }
-                if input_state.down { camera.process_keyboard(CameraMovement::Down, dt); }
+                let colliders = [cube_collider];
+                if input_state.forward { camera.process_keyboard_collision(CameraMovement::Forward, dt, &colliders); }
+                if input_state.backward { camera.process_keyboard_collision(CameraMovement::Backward, dt, &colliders); }
+                if input_state.left { camera.process_keyboard_collision(CameraMovement::Left, dt, &colliders); }
+                if input_state.right { camera.process_keyboard_collision(CameraMovement::Right, dt, &colliders); }
+                if input_state.up { camera.process_keyboard_collision(CameraMovement::Up, dt, &colliders); }
+                if input_state.down { camera.process_keyboard_collision(CameraMovement::Down, dt, &colliders); }
 
                 app.draw_frame(&window, &camera);
             }


### PR DESCRIPTION
## Summary
- add Axis-Aligned Bounding Box definition
- extend camera with aabb and collision aware movement
- update main to use collision logic when moving the camera

## Testing
- `cargo build`

------
https://chatgpt.com/codex/tasks/task_e_688697d8acd4832286310cfe219a0e7b